### PR TITLE
Supprime les AL de la base ressources

### DIFF
--- a/openfisca_france_local/departements/cotes_d_armor/fonds_solidarite_logement/base_ressource.py
+++ b/openfisca_france_local/departements/cotes_d_armor/fonds_solidarite_logement/base_ressource.py
@@ -37,7 +37,6 @@ class cotes_d_armor_fonds_solidarite_logement_base_ressource_mensuelle(Variable)
         family_resource_names = [
             'ada',
             'af',
-            'aide_logement',
             'asf',
             'aspa',
             'cf',

--- a/tests/departements/cotes_d_armor/base_ressource.yml
+++ b/tests/departements/cotes_d_armor/base_ressource.yml
@@ -32,7 +32,7 @@
       _:
         personne_de_reference: [p1]
   output:
-    cotes_d_armor_fonds_solidarite_logement_base_ressource_mensuelle: 2**23-1
+    cotes_d_armor_fonds_solidarite_logement_base_ressource_mensuelle: 2**23-1 - 2**15
 
 - period: 2019-04
   input:


### PR DESCRIPTION
Les AL sont à prendre en compte dans le calcul du taux d'effort mais pas dans la base ressources.